### PR TITLE
[Feature] Made ‘checkIfEmailExists’ method public

### DIFF
--- a/src/Contracts/HelloDialogHandlerInterface.php
+++ b/src/Contracts/HelloDialogHandlerInterface.php
@@ -44,4 +44,13 @@ interface HelloDialogHandlerInterface
      */
     public function getTemplateContents($templateId, array $replaces = []);
 
+    /**
+     * Checks if email exists in HelloDialog. Note that it only checks whether it exists
+     * as a confirmed contact.
+     *
+     * @param string $email
+     * @return bool
+     */
+    public function checkIfEmailExists($email);
+
 }

--- a/src/HelloDialogHandler.php
+++ b/src/HelloDialogHandler.php
@@ -253,10 +253,13 @@ class HelloDialogHandler implements HelloDialogHandlerInterface
 
 
     /**
+     * Checks if email exists in HelloDialog. Note that it only checks whether it exists
+     * as a confirmed contact.
+     *
      * @param string $email
      * @return bool
      */
-    protected function checkIfEmailExists($email)
+    public function checkIfEmailExists($email)
     {
         $existance = $this->getApiInstance(static::API_CONTACTS)
             ->condition('email', $email, 'equals')


### PR DESCRIPTION
Because checking whether or not a contact already exists is something commonly used for determining what actions to undertake, I made the method `HelloDialogHandler::checkIfEmailExists($email)` public.

I updated the associated contract to reflect those changes.

Also, I added some comments to the doc block, to let people know that the method *ONLY* checks for confirmed contacts.