### PR TITLE
Check Laravel version, before attempting to register the Hellodialog …

### DIFF
--- a/src/HelloDialogServiceProvider.php
+++ b/src/HelloDialogServiceProvider.php
@@ -43,6 +43,13 @@ class HelloDialogServiceProvider extends ServiceProvider
      */
     protected function registerHelloDialogMailDriver()
     {
+        list($major, $minor) = $this->getLaravelVersion();
+
+        // Laravel needs to be at least version 5.2 for the swift.transport extension
+        if (($major == 5 && $minor <= 1) ||  $major < 5) {
+            return;
+        }
+
         $this->app['swift.transport']->extend(
             'hellodialog',
             $this->app->share(function ($app) {
@@ -50,5 +57,20 @@ class HelloDialogServiceProvider extends ServiceProvider
                 return new HelloDialogTransport($handler);
             })
         );
+    }
+
+    /**
+     * Returns version of Laravel application.
+     *
+     * @return array
+     */
+    private function getLaravelVersion()
+    {
+        preg_match('#^(?<major>\d+)\.(?<minor>\d+)(?:\..*)?$#', Application::VERSION, $matches);
+
+        $major = (int) $matches['major'];
+        $minor = (int) $matches['minor'];
+
+        return [ $major, $minor ];
     }
 }

--- a/src/HelloDialogServiceProvider.php
+++ b/src/HelloDialogServiceProvider.php
@@ -5,6 +5,7 @@ use Czim\HelloDialog\Contracts\HelloDialogApiFactoryInterface;
 use Czim\HelloDialog\Contracts\HelloDialogHandlerInterface;
 use Czim\HelloDialog\Factories\HelloDialogApiFactory;
 use Czim\HelloDialog\Mail\HelloDialogTransport;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
 class HelloDialogServiceProvider extends ServiceProvider


### PR DESCRIPTION
Laravel 5.1 and lower don't appear to have the `swift.transport` binding, resulting in a fatal error application wide.