### PR TITLE
Add support for reply-to mail in transactional mail

### DIFF
--- a/src/Contracts/HelloDialogHandlerInterface.php
+++ b/src/Contracts/HelloDialogHandlerInterface.php
@@ -10,21 +10,22 @@ interface HelloDialogHandlerInterface
 {
 
     /**
-     * @param string     $to
-     * @param string     $subject
-     * @param int        $template
-     * @param null|array $from associative, 'email', 'name' keys
-     * @param array      $replaces
+     * @param string      $to
+     * @param string      $subject
+     * @param int         $template
+     * @param null|array  $from associative, 'email', 'name' keys
+     * @param array       $replaces
+     * @param null|string $replyToMail
      * @return bool
      * @throws HelloDialogErrorException
      * @throws HelloDialogGeneralException
      */
-    public function transactional($to, $subject, $template = null, array $from = null, array $replaces = []);
+    public function transactional($to, $subject, $template = null, array $from = null, array $replaces = [], $replyToMail = null);
 
     /**
      * @param array  $fields
      * @param string $state
-     * @return bool
+     * @return string|int|false    contact ID or false if failed
      */
     public function saveContact(array $fields, $state = ContactType::OPT_IN);
 


### PR DESCRIPTION
This adds support for the `reply-to` mail in transactional mail calls. This is an optional parameter, that may be used in case the `reply-to` header should be different than the `from` headers.